### PR TITLE
Add support for Native Facebook App interactions for iOS 9.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ recommended). If you want a hook to run before another one, reorder the `<hook
 * **usage**: `<hook type="after_prepare" src="package-hooks/ios9_allow_http.sh" />`
 * **function**: Sets `NSAllowsArbitraryLoads` to true in your `.plist` file,
   allowing all regular HTTP connections in your app again for iOS9.
+  
+##### `ios9_allow_native_fb.sh`
+
+* **author**: [@carson-drake](https://github.com/carson-drake)
+* **usage**: `<hook type="after_prepare" src="package-hooks/ios9_allow_native_fb.sh" />`
+* **function**: Deletes `LSApplicationQueriesSchemes` and then reads the necessary   
+  listings to communicate with Facebook natively to the `.plist` file,
+  allowing login and other features to occur natively rather than in safari.  
+* **credit**: [@mablack](https://github.com/mablack)
 
 ### Use these hooks locally
 

--- a/ios9_allow_native_fb.sh
+++ b/ios9_allow_native_fb.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+PLIST=platforms/ios/*/*-Info.plist
+ 
+# Bypass ATS for test servers
+cat << EOF |
+Delete :LSApplicationQueriesSchemes
+Add :LSApplicationQueriesSchemes array
+Add :LSApplicationQueriesSchemes:0 string 'fbapi'                                                             
+Add :LSApplicationQueriesSchemes:1 string 'fbapi20130214'                                                     
+Add :LSApplicationQueriesSchemes:2 string 'fbapi20130410'                                                     
+Add :LSApplicationQueriesSchemes:3 string 'fbapi20130702'                                                     
+Add :LSApplicationQueriesSchemes:4 string 'fbapi20131010'
+Add :LSApplicationQueriesSchemes:5 string 'fbapi20131219'                                                     
+Add :LSApplicationQueriesSchemes:6 string 'fbapi20140410'                                                     
+Add :LSApplicationQueriesSchemes:7 string 'fbapi20140116'                                                     
+Add :LSApplicationQueriesSchemes:8 string 'fbapi20150313'                                                     
+Add :LSApplicationQueriesSchemes:9 string 'fbapi20150629'                                                     
+Add :LSApplicationQueriesSchemes:10 string 'fbauth'                                                            
+Add :LSApplicationQueriesSchemes:11 string 'fbauth2'                                                           
+EOF
+while read line
+do
+/usr/libexec/PlistBuddy -c "$line" $PLIST
+done
+ 
+true


### PR DESCRIPTION
Added support for Native Facebook login (and other Facebook services) by editing the `.plist` file after_prepare. 
