### PR TITLE
Less destructive fix for phonegap-plugin-barcodescanner issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,14 @@ recommended). If you want a hook to run before another one, reorder the `<hook
 * **function**: Deletes `LSApplicationQueriesSchemes` and then reads the necessary   
   listings to communicate with Facebook natively to the `.plist` file,
   allowing login and other features to occur natively rather than in safari.  
-* **credit**: [@mablack](https://github.com/mablack)
+* **credit**: [@mablack](https://github.com/mablack)  
+  
+##### `android_ignore_translation_errors.js`
+
+* **author**: Ionic
+* **usage**: `<hook type="after_prepare" src="package-hooks/android_ignore_translation_errors.js" />`
+* **function**: After Android prepare, add ` build-extras.gradle` to android platform root to  
+  allow android-lint to ignore the translation errors introduced when including `phonegap-plugin-barcodescanner`.
 
 ### Use these hooks locally
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ recommended). If you want a hook to run before another one, reorder the `<hook
   
 ##### `android_ignore_translation_errors.js`
 
-* **author**: Ionic
+* **author**: [@carson-drake](https://github.com/carson-drake)
 * **usage**: `<hook type="after_prepare" src="package-hooks/android_ignore_translation_errors.js" />`
 * **function**: After Android prepare, add ` build-extras.gradle` to android platform root to  
   allow android-lint to ignore the translation errors introduced when including `phonegap-plugin-barcodescanner`.

--- a/android_ignore_translation_errors.js
+++ b/android_ignore_translation_errors.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+// add additional build-extras.gradle file to instruct android's lint to ignore translation errors
+// v0.1.c
+// causing error in the build --release
+// Issue: https://github.com/phonegap/phonegap-plugin-barcodescanner/issues/80
+//
+// Warning: This solution does not solve the problem only makes it possible to build --release
+
+var fs = require('fs');
+
+var rootdir = process.argv[2];
+
+
+if(rootdir){
+	
+	var platforms = (process.env.CORDOVA_PLATFORMS ? process.env.CORDOVA_PLATFORMS.split(',') : []);
+	for(var x = 0; x < platforms.length; x++){
+		var platform = platforms[x].trim().toLowerCase();
+		try{
+			if(platform == 'android'){
+				var lintOptions = 'android { \nlintOptions {\ndisable \'MissingTranslation\' \ndisable \'ExtraTranslation\' \n} \n}';
+				fs.writeFileSync('platforms/android/build-extras.gradle', lintOptions, 'UTF-8');
+				process.stdout.write('Added build-extras.gradle ');
+			}
+		}catch(e){
+			process.stdout.write(e);
+		}
+	}
+}


### PR DESCRIPTION
Rather than removing plugin files this hook just extends android's lint configuration to ignore the translation errors.
