### PR TITLE
Update LSApplicationQueriesSchemes to match the current values

### DIFF
--- a/ios9_allow_native_fb.sh
+++ b/ios9_allow_native_fb.sh
@@ -20,8 +20,10 @@ Add :LSApplicationQueriesSchemes:6 string 'fbapi20140410'
 Add :LSApplicationQueriesSchemes:7 string 'fbapi20140116'
 Add :LSApplicationQueriesSchemes:8 string 'fbapi20150313'
 Add :LSApplicationQueriesSchemes:9 string 'fbapi20150629'
-Add :LSApplicationQueriesSchemes:10 string 'fbauth'
-Add :LSApplicationQueriesSchemes:11 string 'fbauth2'
+Add :LSApplicationQueriesSchemes:10 string 'fbapi20160328'
+Add :LSApplicationQueriesSchemes:11 string 'fbauth'
+Add :LSApplicationQueriesSchemes:12 string 'fbauth2'
+Add :LSApplicationQueriesSchemes:13 string 'fb-messenger-api20140430'
 EOF
 while read line
 do


### PR DESCRIPTION
As referenced in https://developers.facebook.com/docs/ios/ios9

> If you're recompiling with iOS SDK 9.0, add the following to your application's plist if you're using a version of the SDK v4.5 or older:

``` xml
<key>LSApplicationQueriesSchemes</key>
<array>
    <string>fbapi</string>
    <string>fbapi20130214</string>
    <string>fbapi20130410</string>
    <string>fbapi20130702</string>
    <string>fbapi20131010</string>
    <string>fbapi20131219</string>    
    <string>fbapi20140410</string>
    <string>fbapi20140116</string>
    <string>fbapi20150313</string>
    <string>fbapi20150629</string>
    <string>fbapi20160328</string> 
    <string>fbauth</string>
    <string>fbauth2</string>
    <string>fb-messenger-api20140430</string>
</array>
```
