### PR TITLE
Create ios9_allow_native_whatsapp.sh

### DIFF
--- a/ios9_allow_native_whatsapp.sh
+++ b/ios9_allow_native_whatsapp.sh
@@ -1,18 +1,44 @@
 #!/bin/bash
 
 if [[ ! -f /usr/libexec/PlistBuddy ]]; then
-    exit 0
+exit 0
 fi
 
 PLIST=platforms/ios/*/*-Info.plist
+APPLICATION='whatsapp' # The application we want to add
 
-# Bypass ATS for test servers
-cat << EOF |
-Delete :LSApplicationQueriesSchemes
+
+# Adds the application with new LSApplicationQueriesSchemes array
+function AddApplicationWithNewArray {
+cat << EOF | # Bypass ATS for test servers
 Add :LSApplicationQueriesSchemes array
-Add :LSApplicationQueriesSchemes:0 string 'whatsapp'
+Add :LSApplicationQueriesSchemes:0 string $APPLICATION
 EOF
 while read line
 do
-    /usr/libexec/PlistBuddy -c "$line" $PLIST
+/usr/libexec/PlistBuddy -c "$line" $PLIST
 done
+}
+
+# Adds the application without new LSApplicationQueriesSchemes array
+function AddApplicationWithoutNewArray {
+cat << EOF | # Bypass ATS for test servers
+Add :LSApplicationQueriesSchemes:0 string $APPLICATION
+EOF
+while read line
+do
+/usr/libexec/PlistBuddy -c "$line" $PLIST
+done
+}
+
+val=$(/usr/libexec/PlistBuddy -x -c 'print ":LSApplicationQueriesSchemes"' $PLIST 2>/dev/null)
+
+exitCode=$?
+if [ "$exitCode" -eq "0" ] # Found the LSApplicationQueriesSchemes element, add just the application
+then
+if [[ ! "$val" =~ "<string>$APPLICATION</string>" ]]; then # If the application does not exist
+AddApplicationWithoutNewArray
+fi
+else # Didn't find LSApplicationQueriesSchemesKey element, add the element with the application
+AddApplicationWithNewArray
+fi

--- a/ios9_allow_native_whatsapp.sh
+++ b/ios9_allow_native_whatsapp.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [[ ! -f /usr/libexec/PlistBuddy ]]; then
+    exit 0
+fi
+
+PLIST=platforms/ios/*/*-Info.plist
+
+# Bypass ATS for test servers
+cat << EOF |
+Delete :LSApplicationQueriesSchemes
+Add :LSApplicationQueriesSchemes array
+Add :LSApplicationQueriesSchemes:0 string 'whatsapp'
+EOF
+while read line
+do
+    /usr/libexec/PlistBuddy -c "$line" $PLIST
+done


### PR DESCRIPTION
As referenced at https://www.whatsapp.com/faq/he/iphone/23559013,
Adding 'whatsapp' key to LSApplicationQueriesSchemes will white list whatsapp on the Application Query Scheme
