### PR TITLE
Look for the config files in www

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ recommended). If you want a hook to run before another one, reorder the `<hook
 
 * **author**: [@rolandjitsu](https://github.com/rolandjitsu)
 * **usage**: `<hook type="after_prepare" src="package-hooks/copy_google_services_config_files.js" />`
-* **function**: Copy `google-services.json` and/or `GoogleService-Info.plist` from the root of the project to Android/iOS platform specific required destinations to enable usage of [cordova-plugin-firebase](https://github.com/arnesson/cordova-plugin-firebase) when the build is done in Ionic Cloud.
+* **function**: Copy `google-services.json` and/or `GoogleService-Info.plist` to Android/iOS platform specific required destinations to enable usage of [cordova-plugin-firebase](https://github.com/arnesson/cordova-plugin-firebase) when the build is done in Ionic Cloud. Use [@ionic/app-scripts](https://github.com/driftyco/ionic-app-scripts) to copy the config files in `www` at build time (this hook will search for them at that location).
 
 ##### `ios9_allow_http.sh`
 

--- a/copy_google_services_config_files.js
+++ b/copy_google_services_config_files.js
@@ -29,7 +29,8 @@ if (directoryExists('platforms/android')) {
 function copyIosKey() {
     var paths = [
         'GoogleService-Info.plist',
-        'platforms/ios/www/GoogleService-Info.plist'
+        'platforms/ios/www/GoogleService-Info.plist',
+        'www/GoogleService-Info.plist'
     ];
 
     for (var i = 0; i < paths.length; i++) {
@@ -49,7 +50,8 @@ function copyIosKey() {
 function copyAndroidKey() {
     var paths = [
         'google-services.json',
-        'platforms/android/assets/www/google-services.json'
+        'platforms/android/assets/www/google-services.json',
+        'www/google-services.json'
     ];
 
     for (var i = 0; i < paths.length; i++) {


### PR DESCRIPTION
This adds an extra location to look for the firebase config files. Because the `ionic package` command only uploads `www`, `package.json`, `config.xml` and `resources` paths to the cloud, we need to place the config files in `www`.

The copy config from app-scripts can copy the config files from root to `www` so we don't need to keep anything in `www` in VC.