### PR TITLE
added new hooks for handling addition of framework file

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ recommended). If you want a hook to run before another one, reorder the `<hook
 * **usage**: `<hook type="after_platform_add" src="package-hooks/iosrtc-swift-support.js" />`
 * **function**: Adds `swift` support by adding universal objective c bridge to project.
 
+##### `twilio.js`
+
+* **author**: David Hasenjaeger at Wirestorm Innovations.
+* **usage**: `<hook type="after_platform_add" src="package-hooks/twilio.js" />`
+* **function**: Adds TwilioVoiceClient.framework file reference to "Frameworks" and "Embed Frameworks".
+
+##### `twilio.sh`
+
+* **author**: David Hasenjaeger at Wirestorm Innovations.
+* **usage**: `<hook type="after_platform_add" src="package-hooks/twilio.sh" />`
+* **function**: Downloads TwilioVoiceClient.framework file to platforms/ios/.  Necessary for running the twilio-voice-phonegap-plugin.
+
 
 
 ### Contributing

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/driftyco/ionic-package-hooks#readme",
   "dependencies": {
+    "plist-generator": "0.0.1",
     "xcode": "^0.8.2"
   }
 }

--- a/twilio.js
+++ b/twilio.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+// ********************************************************************
+// Making PlistObject and generating new project.pbxproj file
+var PlistObject = require('plist-generator'),
+    fs = require('fs'),
+    path = require('path');
+
+
+module.exports = function(context) {
+  // Create PlistObject to track changes to the project.pbxproj file
+  var configContents = fs.readFileSync(
+    path.join(
+      context.opts.projectRoot,
+      'config.xml'
+    ),
+    'utf8'
+  );
+  var projectName = /<name>([\s\S]*)<\/name>/mi.exec(configContents)[1].trim();
+  var pbxprojSource = path.join(
+    context.opts.projectRoot,
+    'platforms/ios/',
+    projectName + '.xcodeproj/project.pbxproj'
+  ),
+      plistObject = new PlistObject(fs.readFileSync(pbxprojSource, 'utf8'));
+
+  if (!plistObject.plistData) {
+    console.log('project.pbxproj isn\'t in a recognized format.');
+    console.log('This most likely means that the pbxproj file is corrupted.');
+    return;
+  }
+
+  if (plistObject.findObject('TwilioVoiceClient.framework')) {
+    return console.log('TwilioVoiceClient.framework already added.');
+  }
+
+  // Add TwilioVoiceClient.framework to Frameworks and Embed Frameworks
+  plistObject.addFrameworkFile('TwilioVoiceClient.framework', '', true);
+  // Add a run script to modify the binary TwilioVoiceClient when making builds
+  //  so that they only contain the appropriate binaries.  The app store will
+  //  reject the app unless this is included.
+  var runScriptContents = 'APP_PATH=\\"${TARGET_BUILD_DIR}/${WRAPPER_NAME}\\"\\n\\n' +
+    '# This script loops through the frameworks embedded in the application and\\n' +
+    '# removes unused architectures.\\nfind \\"$APP_PATH\\" -name \'*.framework\'' +
+    ' -type d | while read -r FRAMEWORK\\ndo\\n' +
+    'FRAMEWORK_EXECUTABLE_NAME=$(defaults read \\"$FRAMEWORK/Info.plist\\" ' +
+    'CFBundleExecutable)\\nFRAMEWORK_EXECUTABLE_PATH=\\"$FRAMEWORK/' +
+    '$FRAMEWORK_EXECUTABLE_NAME\\"\\necho \\"Executable is ' +
+    '$FRAMEWORK_EXECUTABLE_PATH\\"\\n\\nEXTRACTED_ARCHS=()\\n\\nfor ARCH in ' +
+    '$ARCHS\\ndo\\necho \\"Extracting $ARCH from $FRAMEWORK_EXECUTABLE_NAME\\"\\n' +
+    'lipo -extract \\"$ARCH\\" \\"$FRAMEWORK_EXECUTABLE_PATH\\" -o ' +
+    '\\"$FRAMEWORK_EXECUTABLE_PATH-$ARCH\\"\\n' +
+    'EXTRACTED_ARCHS+=(\\"$FRAMEWORK_EXECUTABLE_PATH-$ARCH\\")\\ndone\\n\\n' +
+    'echo \\"Merging extracted architectures: ${ARCHS}\\"\\nlipo -o ' +
+    '\\"$FRAMEWORK_EXECUTABLE_PATH-merged\\" -create \\"${EXTRACTED_ARCHS[@]}\\"\\n' +
+    'rm \\"${EXTRACTED_ARCHS[@]}\\"\\n\\necho \\"Replacing original executable with ' +
+    'thinned version\\"\\nrm \\"$FRAMEWORK_EXECUTABLE_PATH\\"\\n' +
+    'mv \\"$FRAMEWORK_EXECUTABLE_PATH-merged\\" \\"$FRAMEWORK_EXECUTABLE_PATH\\"\\n\\n' +
+    'done';
+  plistObject.addShellScript(runScriptContents);
+
+  fs.writeFileSync(pbxprojSource, plistObject.build());
+  console.log('Finished modifying project.pbxproj file');
+  // End making PlistObject and generating new project.pbxproj file
+  // ********************************************************************
+}

--- a/twilio.sh
+++ b/twilio.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Download beta7 of the twilio voice client framework
+curl https://media.twiliocdn.com/sdk/ios/voice/releases/2.0.0-beta7/twilio-voice-ios-2.0.0-beta7.tar.bz2 | tar xvj twilio-voice-ios/TwilioVoiceClient.framework/
+# Move file to correct location in file structure
+mv twilio-voice-ios/TwilioVoiceClient.framework/ platforms/ios/TwilioVoiceClient.framework/
+rm -r twilio-voice-ios/


### PR DESCRIPTION
There are two hooks added in this PR.
- twilio.sh downloads the TwilioVoiceClient.framwork version 2.0.0-beta7 and adds it to the platforms/ios/ directory.
- twilio.js adds a file reference to this framework and adds it to the embedded frameworks
This framework file is necessary for using the twilio-voice-phonegap-plugin