### PR TITLE
ios_dir directory structure was broken!

### DIFF
--- a/copy_google_services_config_files.js
+++ b/copy_google_services_config_files.js
@@ -16,8 +16,8 @@ var ANDROID_DIR = 'platforms/android';
 var PLATFORM = {
     IOS: {
         dest: [
-            IOS_DIR + name + '/Resources/GoogleService-Info.plist',
-            IOS_DIR + name + '/Resources/Resources/GoogleService-Info.plist'
+            IOS_DIR + '/' + name + '/Resources/GoogleService-Info.plist',
+            IOS_DIR + '/' + name + '/Resources/Resources/GoogleService-Info.plist'
         ],
         src: [
             'GoogleService-Info.plist',


### PR DESCRIPTION
This hook was copying GoogleServices-Info.plist to broken destination directory. Missing a '/' between IOS_DIR and name.