### PR TITLE
Updated iosrtc-swift-support.js hook

### DIFF
--- a/iosrtc-swift-support.js
+++ b/iosrtc-swift-support.js
@@ -3,15 +3,17 @@
 'use strict';
 
 // This hook automates this:
-// https://github.com/eface2face/cordova-plugin-iosrtc/blob/master/docs/Building.md
+// https://github.com/BasqueVoIPMafia/cordova-plugin-iosrtc/blob/master/docs/Building.md
 
 var
 	fs = require("fs"),
 	path = require("path"),
 	xcode = require('xcode'),
 
-	BUILD_VERSION = '9.2',
+	BUILD_VERSION = '9.0',
 	BUILD_VERSION_XCODE = '"' + BUILD_VERSION + '"',
+	SWIFT_VERSION = '3.0',
+	SWIFT_VERSION_XCODE = '"' + SWIFT_VERSION + '"',
 	RUNPATH_SEARCH_PATHS = '@executable_path/Frameworks',
 	RUNPATH_SEARCH_PATHS_XCODE = '"' + RUNPATH_SEARCH_PATHS + '"',
 	ENABLE_BITCODE = 'NO',
@@ -85,6 +87,7 @@ module.exports = function (context) {
 	debug('- "Runpath Search Paths" to: ' + RUNPATH_SEARCH_PATHS_XCODE);
 	debug('- "Objective-C Bridging Header" to: ' + swiftBridgingHeadXcode);
 	debug('- "ENABLE_BITCODE" set to: ' + ENABLE_BITCODE_XCODE);
+	debug('- "SWIFT_VERSION" set to: ' + SWIFT_VERSION_XCODE);
 
 
 	// Massaging the files
@@ -94,6 +97,7 @@ module.exports = function (context) {
 	swiftOptions.push('SWIFT_OBJC_BRIDGING_HEADER = ' + swiftBridgingHead);
 	swiftOptions.push('IPHONEOS_DEPLOYMENT_TARGET = ' + BUILD_VERSION);
 	swiftOptions.push('ENABLE_BITCODE = ' + ENABLE_BITCODE);
+	swiftOptions.push('SWIFT_VERSION = ' + SWIFT_VERSION);
 	// NOTE: Not needed
 	// swiftOptions.push('EMBEDDED_CONTENT_CONTAINS_SWIFT = YES');
 	fs.appendFileSync(xcconfigPath, swiftOptions.join('\n'));
@@ -119,6 +123,7 @@ module.exports = function (context) {
 			buildSettings.SWIFT_OBJC_BRIDGING_HEADER = swiftBridgingHeadXcode;
 			buildSettings.IPHONEOS_DEPLOYMENT_TARGET = BUILD_VERSION_XCODE;
 			buildSettings.ENABLE_BITCODE = ENABLE_BITCODE_XCODE;
+			buildSettings.SWIFT_VERSION = SWIFT_VERSION_XCODE;
 		});
 
 		// Writing the file again


### PR DESCRIPTION
Update to the latest version of the iosrtc build hook.

Upstream: [iosrtc-swift-support.js](https://raw.githubusercontent.com/eface2face/cordova-plugin-iosrtc/master/extra/hooks/iosrtc-swift-support.js)